### PR TITLE
Remove blog draft flag in favor of PR-based publishing

### DIFF
--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -103,7 +103,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$DIGEST_BRANCH"
           git add "$DIGEST_FILE"
-          git commit -m "content: add $DIGEST_DATE developer digest draft"
+          git commit -m "content: add $DIGEST_DATE developer digest"
           git push --set-upstream origin "$DIGEST_BRANCH"
 
           echo "date=$DIGEST_DATE" >> "$GITHUB_OUTPUT"
@@ -123,18 +123,17 @@ jobs:
             --head "$DIGEST_BRANCH" \
             --title "Developer digest: $DIGEST_DATE" \
             --body "$(cat <<EOF
-          ## Daily digest draft
+          ## Daily digest
 
-          Generated \`$DIGEST_FILE\` with \`draft: true\`.
+          Generated \`$DIGEST_FILE\`.
 
           Before publishing:
 
           - Proofread the article and verify its source links.
           - Make any editorial changes in this pull request.
-          - Change \`draft: true\` to \`draft: false\`.
           - Run or confirm the Astro build.
           - Mark this pull request ready and merge it.
 
-          The digest remains hidden from the public blog until \`draft\` is set to \`false\` and this pull request is merged.
+          The digest remains off the live site until this pull request is merged.
           EOF
           )"

--- a/docs/developer-digest.md
+++ b/docs/developer-digest.md
@@ -31,7 +31,6 @@ title: "Digest title"
 description: "A short summary shown on the blog listing and in page metadata."
 pubDate: 2026-06-15
 tags: ["AI", "TypeScript", "Developer Tools"]
-draft: false
 ---
 
 Opening context for the day's digest.
@@ -56,10 +55,8 @@ Optional frontmatter:
 | --- | --- | --- |
 | `updatedDate` | date | Date of the latest meaningful revision |
 | `heroImage` | string | Site-relative or external hero image URL |
-| `draft` | boolean | Hides the post when `true`; defaults to `false` |
 
-Only non-draft posts appear on `/blog` or receive public routes. Posts are
-sorted by publication date, newest first.
+Posts are sorted by publication date, newest first.
 
 ## Manual Publishing
 
@@ -81,7 +78,6 @@ Published posts are available at `/blog/YYYY-MM-DD-digest/`.
 Scheduled GitHub Action
 → fetch public developer source feeds
 → generate a Markdown digest with the Gemini API
-→ save it with draft: true
 → validate the Astro build
 → commit to a dated automation branch
 → open a draft pull request
@@ -115,11 +111,12 @@ Before merging:
 
 1. Proofread the article and verify its source links.
 2. Make any editorial changes on the pull request branch.
-3. Change `draft: true` to `draft: false`.
-4. Confirm the build passes.
-5. Mark the pull request ready and merge it.
+3. Confirm the build passes.
+4. Mark the pull request ready and merge it.
 
-The merge triggers the existing deployment and publishes the post.
+The merge triggers the existing deployment and publishes the post. Until then,
+the digest stays off the live site because it only exists on the pull request
+branch.
 
 ## Generate Locally
 

--- a/scripts/generate-digest.mjs
+++ b/scripts/generate-digest.mjs
@@ -152,7 +152,6 @@ const markdown = [
   `description: ${JSON.stringify(digest.description)}`,
   `pubDate: ${date}`,
   `tags: ${JSON.stringify(digest.tags)}`,
-  "draft: true",
   "---",
   "",
   digest.body.trim(),
@@ -162,7 +161,7 @@ const markdown = [
 await mkdir(outputDirectory, { recursive: true });
 await writeFile(outputPath, markdown, "utf8");
 
-console.log(`Created ${path.relative(process.cwd(), outputPath)} as a draft.`);
+console.log(`Created ${path.relative(process.cwd(), outputPath)}.`);
 
 async function collectSources() {
   const settled = await Promise.allSettled(

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -91,7 +91,6 @@ const blog = defineCollection({
         updatedDate: z.coerce.date().optional(),
         heroImage: z.string().optional(),
         tags: z.array(z.string()),
-        draft: z.boolean().default(false),
     }),
 });
 

--- a/src/content/blog/2026-06-15-digest.md
+++ b/src/content/blog/2026-06-15-digest.md
@@ -3,7 +3,6 @@ title: "The New Developer Stack Is Not React + TypeScript. It’s Judgment."
 description: "A daily developer digest on AI-assisted development, frontend engineering, security, and architecture."
 pubDate: 2026-06-15
 tags: ["AI", "Frontend", "React", "Software Architecture", "Developer Tools"]
-draft: false
 ---
 
 The modern developer stack is changing, but not in the way a package.json file can capture.

--- a/src/content/blog/2026-06-17-digest.md
+++ b/src/content/blog/2026-06-17-digest.md
@@ -3,7 +3,6 @@ title: "Developer Digest: The Rise of Agentic Frameworks and AI Migration Tools"
 description: "This week's digest covers the emergence of open-source agent frameworks, new AWS migration tooling for generative AI, and advancements in deployment simulation."
 pubDate: 2026-06-17
 tags: ["AI","Cloud Architecture","Agentic Workflows","AWS","Developer Tools"]
-draft: true
 ---
 
 ## The Shift Toward Agentic Infrastructure

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -3,7 +3,7 @@ import { getCollection, render, type CollectionEntry } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  const posts = await getCollection("blog");
 
   return posts.map((post) => ({
     params: { slug: post.id },

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,9 +2,9 @@
 import { getCollection } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
 
-const posts = (await getCollection("blog"))
-  .filter((post) => !post.data.draft)
-  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+const posts = (await getCollection("blog")).sort(
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+);
 
 const formatDate = (date: Date) =>
   new Intl.DateTimeFormat("en", {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,6 @@ import { site } from "../data/site";
 
 const now = await getEntry("now", "index");
 const posts = (await getCollection("blog"))
-  .filter((post) => !post.data.draft)
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
   .slice(0, 3);
 


### PR DESCRIPTION
## Summary
- Removes the `draft` frontmatter field from the blog content schema and all existing digest posts.
- Blog index, post pages, and homepage now include every post in `src/content/blog/` without draft filtering.
- Updates the digest generator, workflow, and docs so draft PRs are the review gate instead of `draft: true` in frontmatter.

## Test plan
- [x] `npm run build` succeeds
- [x] `/blog` lists both digest posts
- [x] `/blog/2026-06-17-digest/` and `/blog/2026-06-15-digest/` render
- [ ] Confirm homepage recent writing shows both posts
- [ ] Verify daily digest workflow PR body reflects the updated publish flow


Made with [Cursor](https://cursor.com)